### PR TITLE
Esg-547 : optimize stm32 spidev

### DIFF
--- a/arch/arm/boot/dts/imx6ul-imx6ull-var-som-wiv2-board.dtsi
+++ b/arch/arm/boot/dts/imx6ul-imx6ull-var-som-wiv2-board.dtsi
@@ -396,7 +396,7 @@
 };
 */
 
-/* SPI STM 32*/
+/* SPI STM 32 : Master with Slave-Ready GPIO */
 &ecspi4 {
 	/*fsl,spi-num-chipselects = <1>;
 	cs-gpios = <&gpio2 15 0>;*/
@@ -405,6 +405,7 @@
 	/*#address-cells = <0>;
 	spi-slave;*/
 	status = "okay";
+	sready-gpios = <&gpio2 15 GPIO_ACTIVE_LOW>;
 
     /*slave{
         compatible = "spidev";
@@ -412,14 +413,15 @@
 		status = "okay";
     };*/
 	spidev0: spi@0 {
-        compatible = "var,spidev";
-        spi-max-frequency = <4000000>;
-        reg = <0>;
+		compatible = "var,spidev";
+		spi-max-frequency = <4000000>;
+		reg = <0>;
 		status = "okay";
+		sready-gpios = <&gpio2 15 GPIO_ACTIVE_LOW>;
     };
 };
 
-/* SPI AVBx7 */
+/* SPI AVBx7 : Master */
 &ecspi2 {
 	fsl,spi-num-chipselects = <1>;
 	cs-gpios = <0>;

--- a/arch/arm/boot/dts/imx6ul-imx6ull-var-som-wiv2-board.dtsi
+++ b/arch/arm/boot/dts/imx6ul-imx6ull-var-som-wiv2-board.dtsi
@@ -396,7 +396,8 @@
 };
 */
 
-/* SPI STM 32 : Master with Slave-Ready GPIO */
+/* SPI STM 32 : Master with Slave-Ready GPIO
+ * look for spi_imx and spi_bitbang controller */
 &ecspi4 {
 	/*fsl,spi-num-chipselects = <1>;
 	cs-gpios = <&gpio2 15 0>;*/
@@ -404,6 +405,7 @@
 	pinctrl-0 = <&pinctrl_ecspi4>;
 	/*#address-cells = <0>;
 	spi-slave;*/
+	spi-realtime;
 	status = "okay";
 	sready-gpios = <&gpio2 15 GPIO_ACTIVE_LOW>;
 

--- a/drivers/spi/spi-imx.c
+++ b/drivers/spi/spi-imx.c
@@ -1655,6 +1655,9 @@ static int spi_imx_probe(struct platform_device *pdev)
 		spi_drctl = 0;
 	}
 
+	/* provided to tie spi.c layer thanks to spi-bitbang-start */
+	master->rt = of_property_read_bool(np, "spi-realtime");
+
 	platform_set_drvdata(pdev, master);
 
 	master->bits_per_word_mask = SPI_BPW_RANGE_MASK(1, 32);

--- a/drivers/spi/spi.c
+++ b/drivers/spi/spi.c
@@ -1435,7 +1435,7 @@ static void spi_pump_messages(struct kthread_work *work)
  */
 static void spi_set_thread_rt(struct spi_controller *ctlr)
 {
-	struct sched_param param = { .sched_priority = MAX_RT_PRIO / 2 };
+	struct sched_param param = { .sched_priority = 70 };
 
 	dev_info(&ctlr->dev,
 		"will run message pump with realtime priority\n");

--- a/drivers/spi/spidev.c
+++ b/drivers/spi/spidev.c
@@ -5,12 +5,18 @@
  * Copyright (C) 2006 SWAPP
  *	Andrea Paterniani <a.paterniani@swapp-eng.it>
  * Copyright (C) 2007 David Brownell (simplification, cleanup)
+ * Copyright (C) 2024 VOGO S.A.S (parts)
+ *
+ * based on spidev.c
+ *
+ * License terms: GNU General Public License (GPL) version 2
  */
-
 #include <linux/init.h>
 #include <linux/module.h>
 #include <linux/ioctl.h>
 #include <linux/fs.h>
+#include <linux/file.h>
+#include <linux/poll.h>
 #include <linux/device.h>
 #include <linux/err.h>
 #include <linux/list.h>
@@ -27,6 +33,9 @@
 
 #include <linux/uaccess.h>
 
+#include <linux/interrupt.h>
+#include <linux/gpio/consumer.h>
+#include <linux/jiffies.h>
 
 /*
  * This supports access to SPI devices using normal userspace I/O calls.
@@ -76,6 +85,12 @@ struct spidev_data {
 	u8			*tx_buffer;
 	u8			*rx_buffer;
 	u32			speed_hz;
+
+	/* handling of master with slave-ready GPIO scheme. */
+	struct gpio_desc *sready_gpio;
+	int sready_gpio_irq;
+	wait_queue_head_t waitq;
+	u32 sready_msg_counter;
 };
 
 static LIST_HEAD(device_list);
@@ -309,6 +324,91 @@ done:
 	return status;
 }
 
+
+static irqreturn_t spidev_sready_handler(int irq, void *private)
+{
+	struct spidev_data *spidev = private;
+
+	if (0 < spidev->users)
+	{
+		spidev->sready_msg_counter++;
+		wake_up_interruptible(&spidev->waitq);
+	}
+
+	return IRQ_HANDLED;
+}
+
+static int spidev_sready_probe(struct spidev_data *spidev)
+{
+	int ret = 0;
+
+	/* Attempt to grab the GPIO */
+	if (NULL == spidev->sready_gpio) {
+		spidev->sready_gpio = devm_gpiod_get_optional(&spidev->spi->dev, "sready", GPIOD_IN);
+	}
+
+	/* Initialize the wait queue on response to the GPIO rising event. */
+	if (NULL != spidev->sready_gpio) {
+		init_waitqueue_head(&spidev->waitq);
+
+		spidev->sready_msg_counter = 0UL;
+
+		gpiod_direction_input(spidev->sready_gpio);
+
+		spidev->sready_gpio_irq = gpiod_to_irq(spidev->sready_gpio);
+
+		if (spidev->sready_gpio_irq < 0)
+			dev_warn(&spidev->spi->dev, "Can't get irq: %d\n",
+					spidev->sready_gpio_irq);
+		else {
+			ret = devm_request_irq(&spidev->spi->dev,
+					spidev->sready_gpio_irq,
+					spidev_sready_handler,
+					IRQF_TRIGGER_FALLING, "sready",
+					spidev);
+			if (0 != ret)
+				dev_err(&spidev->spi->dev,
+					"cannot request irq");
+		}
+	}
+
+	return ret;
+}
+
+static __poll_t spidev_poll(struct file *filp, poll_table *wait)
+{
+	struct spidev_data *spidev = filp->private_data;
+	__poll_t events = EPOLLHUP;
+
+	if ((NULL != spidev) && (NULL != spidev->sready_gpio))
+	{
+		u32 elapsed = jiffies;
+		int res = wait_event_interruptible(spidev->waitq, (0UL < spidev->sready_msg_counter));
+		if (res >= 0) {
+			events = EPOLLIN | EPOLLRDNORM; // mapps to select READ_FD type.
+		} else {
+			printk_ratelimited(KERN_ERR "spidev_poll wait failed, res = %d\n", res);
+		}
+
+		if (unlikely((1 < (jiffies - elapsed)) || (1 < spidev->sready_msg_counter)))
+		{
+			printk_ratelimited(KERN_ERR	"spidev_poll: long timelaps %lu x10ms, spidev->sready_msg_counter = %lu\n",
+						jiffies - elapsed,
+						spidev->sready_msg_counter);
+		}
+
+		spidev->sready_msg_counter = 0UL;
+	}
+	else
+	{
+		WARN_ONCE(!spidev->sready_gpio,
+			"spidev_poll while no Slave Ready gpio declared.\n");
+	}
+
+	return events;
+}
+
+
 static struct spi_ioc_transfer *
 spidev_get_ioc_message(unsigned int cmd, struct spi_ioc_transfer __user *u_ioc,
 		unsigned *n_ioc)
@@ -335,11 +435,11 @@ spidev_get_ioc_message(unsigned int cmd, struct spi_ioc_transfer __user *u_ioc,
 static long
 spidev_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
-	int			retval = 0;
-	struct spidev_data	*spidev;
-	struct spi_device	*spi;
-	u32			tmp;
-	unsigned		n_ioc;
+	int	retval = 0;
+	struct spidev_data *spidev;
+	struct spi_device *spi;
+	u32	tmp;
+	unsigned int n_ioc;
 	struct spi_ioc_transfer	*ioc;
 
 	/* Check type and command number */
@@ -456,20 +556,22 @@ spidev_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 		break;
 
 	default:
-		/* segmented and/or full-duplex I/O request */
-		/* Check message and copy into scratch area */
-		ioc = spidev_get_ioc_message(cmd,
-				(struct spi_ioc_transfer __user *)arg, &n_ioc);
-		if (IS_ERR(ioc)) {
-			retval = PTR_ERR(ioc);
-			break;
-		}
-		if (!ioc)
-			break;	/* n_ioc is also 0 */
+		{
+			/* segmented and/or full-duplex I/O request */
+			ioc = spidev_get_ioc_message(cmd,
+					(struct spi_ioc_transfer __user *)arg, &n_ioc);
+			if (IS_ERR(ioc)) {
+				retval = PTR_ERR(ioc);
+				break;
+			}
+			if (!ioc)
+				break;	/* n_ioc is also 0 */
 
-		/* translate to spi_message, execute */
-		retval = spidev_message(spidev, ioc, n_ioc);
-		kfree(ioc);
+			/* translate to spi_message, execute */
+			retval = spidev_message(spidev, ioc, n_ioc);
+
+			kfree(ioc);
+		}
 		break;
 	}
 
@@ -640,6 +742,7 @@ static const struct file_operations spidev_fops = {
 	 */
 	.write =	spidev_write,
 	.read =		spidev_read,
+	.poll =		spidev_poll,
 	.unlocked_ioctl = spidev_ioctl,
 	.compat_ioctl = spidev_compat_ioctl,
 	.open =		spidev_open,
@@ -764,9 +867,14 @@ static int spidev_probe(struct spi_device *spi)
 
 	spidev->speed_hz = spi->max_speed_hz;
 
-	if (status == 0)
+	if (status == 0) {
 		spi_set_drvdata(spi, spidev);
-	else
+
+		/* if no slave ready is provided, returns 0 */
+		status = spidev_sready_probe(spidev);
+	}
+
+	if (status != 0)
 		kfree(spidev);
 
 	return status;


### PR DESCRIPTION
This patch series replaces the very poor slave-ready management for SPI3 using gpiod, with a kernel-side waitqueue in the spidev driver. The principle is that any client app (e.g. audio-app) can wait using a poll syscall. The poll will be wokenup by the kernel, when the gpio is asseted. This is must better for realtime and perf, because it saves 2 syscalls per 10ms (poll, rather than poll/read/seek).

In addition, the SPI controlle worker-thread, that wakes spidev is now realtime. Improvement can be seen by doing a cat on /dev/kmsg : later service of the STM32 spi message will print a trace. It is now a very rare event.  

This patch also required changes in audio-app, to use the poll syscall on spidev, and no longuer on the terrible gpiod file.

@JsaVogo  @nguyenmk @GBelkacemi 